### PR TITLE
update to v21

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxserver/nzbget
+FROM linuxserver/nzbget:version-v21.1
 MAINTAINER ullbergm
 
 ARG BUILD_DATE


### PR DESCRIPTION
from [LinuxServer.io Docs](https://fleet.linuxserver.io/image?name=linuxserver/nzbget) need specific tag to get v21 update.